### PR TITLE
Added an option for hiding comments from code chunk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.html
+*.pdf
+*_files/
+.Rproj.user
+*.rproj
+.Rhistory
+!docs/*

--- a/_extensions/code-visibility/code-visibility.lua
+++ b/_extensions/code-visibility/code-visibility.lua
@@ -1,11 +1,8 @@
-
-
-
 -- remove any lines with the hide_line directive.
 function CodeBlock(el)
   if el.classes:includes('cell-code') then
     el.text = filter_lines(el.text, function(line)
-      return not line:match("#| ?hide_line%s*$")
+      return not (line:match("#| ?hide_line%s*$") or line:match("#>"))
     end)
     return el
   end
@@ -30,12 +27,10 @@ function Div(el)
           end
         end
       })
-      
     end
-
   end
-  
 end
+
 
 function filter_lines(text, filter)
   local lines = pandoc.List()

--- a/_extensions/code-visibility/code-visibility.lua
+++ b/_extensions/code-visibility/code-visibility.lua
@@ -1,10 +1,51 @@
+local str = pandoc.utils.stringify
+-- local p = quarto.log.output
+
 -- remove any lines with the hide_line directive.
 function CodeBlock(el)
   if el.classes:includes('cell-code') then
     el.text = filter_lines(el.text, function(line)
-      return not (line:match("#| ?hide_line%s*$") or line:match("#>"))
+      return not line:match("#| ?hide_line%s*$")
     end)
     return el
+  end
+end
+
+-- function for applying comment_directive
+local function apply_cmnt_directives(comment_directive)
+  local cmnt_directive_pattern = "^" .. comment_directive
+  local line_filter = {
+    CodeBlock = function(cb)
+      if cb.classes:includes('cell-code') then
+        cb.text = filter_lines(cb.text, function(line)
+            return not line:match(cmnt_directive_pattern)
+            end)
+        return cb
+      end
+    end
+  }
+  return line_filter
+end
+
+-- function to check whether a value exists in a table
+function has_value(table, value)
+  for k, v in ipairs(table) do
+    if v == value then
+      return true
+    end
+  end
+  return false
+end
+
+-- hide lines with comment directive
+function Pandoc(doc)
+  local meta = doc.meta
+  local cmnt_directive_tbl = {"#>", "//>"}
+  if meta['comment-directive'] then
+    if has_value(cmnt_directive_tbl, str(meta['comment-directive'])) then
+      local comment_directive = str(meta['comment-directive'])
+      return doc:walk(apply_cmnt_directives(comment_directive))
+    end
   end
 end
 

--- a/example.qmd
+++ b/example.qmd
@@ -1,23 +1,41 @@
 ---
-title: "RevealJS"
-format: revealjs
-filters:
+title: "Code Visibility"
+author: Shafayet Khan Shafee
+date: last-modified
+format: html
+comment-directive: "//>"
+filters: 
   - code-visibility
 execute: 
   echo: true
+  eval: false
 ---
 
-## Quarto
+## R
 
 ```{r}
 #| message: false
 #> This is some hidden comment which is visible in code editor
 #> but not in rendered documents
-library(dplyr) #| hide_line
+library(dplyr) 
 
+print("#>") #| hide_line
+#>
 #> more hidden comment
 mtcars %>% 
   select(mpg, am ,vs) %>% 
   group_by(vs) %>% 
   summarise(mean(mpg))
 ```
+
+## Javascript
+
+```{js}
+//> This is some hidden comment which is visible in code editor
+//> but not in rendered documents
+
+function square(x) {
+  return x * x;
+}
+```
+

--- a/example.qmd
+++ b/example.qmd
@@ -3,7 +3,9 @@ title: "Code Visibility"
 author: Shafayet Khan Shafee
 date: last-modified
 format: html
-comment-directive: "//>"
+comment-directive: 
+    - "#>"
+    - "#>"
 filters: 
   - code-visibility
 execute: 
@@ -34,8 +36,15 @@ mtcars %>%
 //> This is some hidden comment which is visible in code editor
 //> but not in rendered documents
 
-function square(x) {
-  return x * x;
-}
+viewof bill_length_min = Inputs.range(
+  [32, 50], 
+  {value: 35, step: 1, label: "Bill length (min):"}
+)
+viewof islands = Inputs.checkbox(
+  ["Torgersen", "Biscoe", "Dream"], 
+  { value: ["Torgersen", "Biscoe"], 
+    label: "Islands:"
+  }
+)
 ```
 

--- a/example.qmd
+++ b/example.qmd
@@ -1,0 +1,23 @@
+---
+title: "RevealJS"
+format: revealjs
+filters:
+  - code-visibility
+execute: 
+  echo: true
+---
+
+## Quarto
+
+```{r}
+#| message: false
+#> This is some hidden comment which is visible in code editor
+#> but not in rendered documents
+library(dplyr) #| hide_line
+
+#> more hidden comment
+mtcars %>% 
+  select(mpg, am ,vs) %>% 
+  group_by(vs) %>% 
+  summarise(mean(mpg))
+```


### PR DESCRIPTION
I have added an option `comment-directives` which can take value either `#>` o  `//>` and then lines in code chunk starting with these either two will not appear in rendered document. I have also added a file `example.qmd` with the examples of this option.